### PR TITLE
Add API handlers for Track and Signal endpoints

### DIFF
--- a/constants/messages.go
+++ b/constants/messages.go
@@ -1,0 +1,22 @@
+package constants
+
+const (
+	// Success Messages
+	MsgCreateSuccess = "Record created successfully"
+	MsgReadSuccess   = "Record retrieved successfully"
+	MsgsReadSuccess  = "Records retrieved successfully"
+	MsgUpdateSuccess = "Record updated successfully"
+	MsgDeleteSuccess = "Record deleted successfully"
+
+	// Error Messages
+	ErrRecordsRetrivedFail = "Retrieve records failed"
+	ErrRecordUpdateFail    = "Update record failed"
+	ErrRecordDeleteFail    = "Delete record failed"
+	ErrRecordCreateFail    = "Create record failed"
+	ErrRecordNotFound      = "Record not found"
+	ErrInvalidInput        = "Invalid input data"
+
+	// Track Signal Association
+	TrackSignalAssociatedSuccess = "Track associated with signal"
+	TrackSignalAssociatedRemoved = "Track-Signal association removed"
+)

--- a/handlers/signal_handler.go
+++ b/handlers/signal_handler.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/labstack/echo/v4"
+
+	"github.com/pushpanthraj/crosstech/railway-signals/constants"
+	"github.com/pushpanthraj/crosstech/railway-signals/repository"
+	"github.com/pushpanthraj/crosstech/railway-signals/utils"
+)
+
+// Get all signals
+func GetSignals(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		signals, err := repository.GetAllSignals(db)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusInternalServerError, constants.ErrRecordsRetrivedFail, err.Error())
+		}
+		return utils.SendResponse(c, http.StatusOK, constants.MsgsReadSuccess, signals)
+	}
+}
+
+// Get all tracks associated with a signal
+func GetTracksBySignal(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, constants.ErrInvalidInput)
+		}
+
+		tracks, err := repository.GetTracksBySignal(db, id)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusNotFound, constants.ErrRecordsRetrivedFail, err.Error())
+		}
+
+		return utils.SendResponse(c, http.StatusOK, constants.MsgsReadSuccess, tracks)
+	}
+}
+
+// Associate a track with a signal
+func AssociateTrackWithSignal(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		trackID, _ := strconv.Atoi(c.Param("track_id"))
+		signalID, _ := strconv.Atoi(c.Param("signal_id"))
+
+		err := repository.AssociateTrackWithSignal(db, trackID, signalID)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusInternalServerError, constants.ErrRecordsRetrivedFail, err.Error())
+		}
+
+		// here retrive signal back in response
+		return utils.SendResponse(c, http.StatusOK, constants.TrackSignalAssociatedSuccess, nil)
+	}
+}
+
+// Remove the association between a signal and a track
+func RemoveTrackSignalAssociation(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		trackID, _ := strconv.Atoi(c.Param("track_id"))
+		signalID, _ := strconv.Atoi(c.Param("signal_id"))
+
+		err := repository.RemoveTrackSignalAssociation(db, trackID, signalID)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, err.Error())
+		}
+
+		// here retrive signal back in response
+		return utils.SendResponse(c, http.StatusOK, constants.TrackSignalAssociatedRemoved, nil)
+	}
+}

--- a/handlers/track_handler.go
+++ b/handlers/track_handler.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/pushpanthraj/crosstech/railway-signals/constants"
+	"github.com/pushpanthraj/crosstech/railway-signals/entity/track"
+	"github.com/pushpanthraj/crosstech/railway-signals/repository"
+	"github.com/pushpanthraj/crosstech/railway-signals/utils"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/labstack/echo/v4"
+)
+
+// Get all tracks with signals
+func GetTracks(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		tracks, err := repository.GetAllTracks(db)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusInternalServerError, constants.ErrRecordsRetrivedFail, err.Error())
+		}
+		return utils.SendResponse(c, http.StatusOK, constants.MsgsReadSuccess, tracks)
+	}
+}
+
+// Get a single track by ID with its signals
+func GetTrackByID(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, constants.ErrInvalidInput)
+		}
+
+		track, err := repository.GetTrackByID(db, id)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusNotFound, constants.ErrRecordNotFound, err.Error())
+		}
+
+		return utils.SendResponse(c, http.StatusOK, constants.MsgReadSuccess, track)
+	}
+}
+
+// Create a new track
+func CreateTrack(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		track := new(track.Track)
+		if err := c.Bind(track); err != nil {
+			return c.JSON(http.StatusBadRequest, err.Error())
+		}
+
+		// for _, val := range track.Signals {
+		// 	val.TrackID = track.ID
+		// }
+		err := repository.CreateTrack(db, track)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusInternalServerError, constants.ErrRecordCreateFail, err.Error())
+		}
+
+		// check if signal exist with same track_id
+
+		return utils.SendResponse(c, http.StatusCreated, constants.MsgCreateSuccess, track)
+	}
+}
+
+// Update an existing track
+func UpdateTrack(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, constants.ErrInvalidInput)
+		}
+
+		track := new(track.Track)
+		if err := c.Bind(track); err != nil {
+			return c.JSON(http.StatusBadRequest, err.Error())
+		}
+
+		track.ID = id
+		err = repository.UpdateTrack(db, track)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusInternalServerError, constants.ErrRecordUpdateFail, err.Error())
+		}
+
+		return utils.SendResponse(c, http.StatusOK, constants.MsgUpdateSuccess, track)
+	}
+}
+
+// Delete a track by ID
+func DeleteTrack(db *pg.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		id, err := strconv.Atoi(c.Param("id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, constants.ErrInvalidInput)
+		}
+
+		err = repository.DeleteTrack(db, id)
+		if err != nil {
+			return utils.SendResponse(c, http.StatusInternalServerError, constants.ErrRecordDeleteFail, err.Error())
+		}
+
+		return utils.SendResponse(c, http.StatusOK, constants.MsgDeleteSuccess, nil)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/pushpanthraj/crosstech/railway-signals/config"
+	"github.com/pushpanthraj/crosstech/railway-signals/handlers"
+
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	db := config.ConnectDB()
+	defer db.Close()
+
+	e := echo.New()
+
+	// Track Routes
+	e.GET("/tracks", handlers.GetTracks(db))          // Get all tracks with signals
+	e.GET("/tracks/:id", handlers.GetTrackByID(db))   // Get a specific track by ID with signals
+	e.POST("/tracks", handlers.CreateTrack(db))       // Create a new track
+	e.PUT("/tracks/:id", handlers.UpdateTrack(db))    // Update an existing track
+	e.DELETE("/tracks/:id", handlers.DeleteTrack(db)) // Delete a track by ID
+
+	// Signal Routes
+	e.GET("/signals", handlers.GetSignals(db))                   // Get all signals
+	e.GET("/signals/:id/tracks", handlers.GetTracksBySignal(db)) // Get all tracks associated with a signal
+
+	// Signal-Track Relationship Routes
+	e.POST("/tracks/:track_id/signals/:signal_id", handlers.AssociateTrackWithSignal(db))       // Associate a track with a signal
+	e.DELETE("/tracks/:track_id/signals/:signal_id", handlers.RemoveTrackSignalAssociation(db)) // Remove association between a track and a signal
+
+	e.Logger.Fatal(e.Start(":8080"))
+}

--- a/repository/signal_repository.go
+++ b/repository/signal_repository.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"github.com/go-pg/pg/v10"
+	"github.com/pushpanthraj/crosstech/railway-signals/entity/signal"
+	"github.com/pushpanthraj/crosstech/railway-signals/entity/track"
+)
+
+func GetAllSignals(db *pg.DB) ([]signal.Signal, error) {
+	var signals []signal.Signal
+	err := db.Model(&signals).Select()
+	return signals, err
+}
+
+func GetTracksBySignal(db *pg.DB, signalID int) ([]track.Track, error) {
+	var tracks []track.Track
+	err := db.Model(&tracks).
+		Join("JOIN signals ON signals.track_id = tracks.id").
+		Where("signals.signal_id = ?", signalID).
+		Select()
+
+	return tracks, err
+}
+
+func GetTracksBySignal1(db *pg.DB, signalID int) ([]track.Track, error) {
+	var tracks []track.Track
+	err := db.Model(&tracks).
+		Join("JOIN signals ON signals.track_id = tracks.id").
+		Where("signals.signal_id = ?", signalID).
+		Select()
+	return tracks, err
+}
+
+func AssociateTrackWithSignal(db *pg.DB, trackID, signalID int) error {
+	_, err := db.Exec("UPDATE signals SET track_id = ? WHERE id = ?", trackID, signalID)
+	return err
+}
+
+func RemoveTrackSignalAssociation(db *pg.DB, trackID, signalID int) error {
+	_, err := db.Exec("UPDATE signals SET track_id = NULL WHERE id = ? AND track_id = ?", signalID, trackID)
+	return err
+}

--- a/repository/track_repository.go
+++ b/repository/track_repository.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"github.com/go-pg/pg/v10"
+	"github.com/pushpanthraj/crosstech/railway-signals/entity/track"
+)
+
+func GetAllTracks(db *pg.DB) ([]track.Track, error) {
+	var tracks []track.Track
+	err := db.Model(&tracks).Relation("Signals").Select()
+	return tracks, err
+}
+
+func GetTrackByID(db *pg.DB, id int) (*track.Track, error) {
+	track := &track.Track{ID: id}
+	err := db.Model(track).Relation("Signals").WherePK().Select()
+	return track, err
+}
+
+func CreateTrack(db *pg.DB, track *track.Track) error {
+	_, err := db.Model(track).Insert()
+	return err
+}
+
+func UpdateTrack(db *pg.DB, track *track.Track) error {
+	_, err := db.Model(track).WherePK().Update()
+	return err
+}
+
+func DeleteTrack(db *pg.DB, id int) error {
+	_, err := db.Model((*track.Track)(nil)).Where("id = ?", id).Delete()
+	return err
+}

--- a/utils/response.go
+++ b/utils/response.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/pushpanthraj/crosstech/railway-signals/entity/signal"
+	"github.com/pushpanthraj/crosstech/railway-signals/entity/track"
+)
+
+// Response struct for all API responses
+type APIResponse struct {
+	Header struct {
+		Message    string `json:"message"`
+		Count      int    `json:"count"`
+		StatusCode int    `json:"status_code"`
+	} `json:"header"`
+	Data interface{} `json:"data"`
+}
+
+// Function to send a response
+func SendResponse(c echo.Context, status int, message string, data interface{}) error {
+	response := APIResponse{
+		Data: data,
+	}
+	response.Header.Message = message
+	response.Header.StatusCode = status
+
+	// // If data is a slice, count the number of items
+	// if d, ok := data.([]interface{}); ok {
+	// 	response.Header.Count = len(d)
+	// } else {
+	// 	response.Header.Count = 1 // Single object
+	// }
+
+	if data != nil {
+		switch v := data.(type) {
+		case []interface{}:
+			response.Header.Count = len(v)
+		case []track.Track:
+			response.Header.Count = len(v)
+		case []signal.Signal:
+			response.Header.Count = len(v)
+		case *track.Track:
+			response.Header.Count = 1
+		case *signal.Signal:
+			response.Header.Count = 1
+		}
+	}
+
+	return c.JSON(status, response)
+}


### PR DESCRIPTION
Implemented API handlers for Track and Signal endpoints

- Create CURD operations endpoints for managing Tracks
- Create GET endpoint to retrieve Signals associated with Tracks
- Set up basic API structure using Echo framework
- Added constants and utils for common use 